### PR TITLE
feat ( dev-env ) : Added live reloading

### DIFF
--- a/.air.toml
+++ b/.air.toml
@@ -1,0 +1,42 @@
+root = "."
+testdata_dir = "testdata"
+tmp_dir = "tmp"
+
+[build]
+  args_bin = []
+  bin = "./tmp/main"
+  cmd = "go build -o ./tmp/main ."
+  delay = 0
+  exclude_dir = ["assets", "tmp", "vendor", "testdata"]
+  exclude_file = []
+  exclude_regex = ["_test.go"]
+  exclude_unchanged = false
+  follow_symlink = false
+  full_bin = ""
+  include_dir = []
+  include_ext = ["go", "tpl", "tmpl", "html"]
+  include_file = []
+  kill_delay = "0s"
+  log = "build-errors.log"
+  rerun = false
+  rerun_delay = 500
+  send_interrupt = false
+  stop_on_error = false
+
+[color]
+  app = ""
+  build = "yellow"
+  main = "magenta"
+  runner = "green"
+  watcher = "cyan"
+
+[log]
+  main_only = false
+  time = false
+
+[misc]
+  clean_on_exit = false
+
+[screen]
+  clear_on_rebuild = false
+  keep_scroll = true

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ go.work
 # env
 .env
 .env.*
+
+# air executable
+tmp/*


### PR DESCRIPTION
## Description

The live reloading strategy is added, with the purpose of not having to build the respective binary every time a change is made.

## Testing

1. Run in terminal:

``` sh
air

```

2. Add the necessary changes for the desired feature.
3. Watch in real time through the terminal, if the change introduced works correctly.

> To use live reloading, you must previously have the [air](https://github.com/cosmtrek/air) tool installed on your computer.



---

## Additional Details (Optional)

For less typing, you could add alias `air='~/.air'` to your `.bashrc` or `.zshrc`.

## Reviews (Optional)

@GuillermoMajano please review this change.