### PR TITLE
build: add Podman support and Container Engine Auto-detection

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,12 +14,38 @@ UID ?= $(shell id -u)
 GODOC_PORT ?= 6060
 ENV_FILE ?= .env
 
+# Load variables from ENV_FILE when it exists (e.g. BUILD_CPU_LIMIT).
+# The leading '-' silences the error if the file is absent.
+-include $(ENV_FILE)
+export
+
 # Container engine detection
-CONTAINER_ENGINE ?= $(shell command -v podman 2> /dev/null || command -v docker 2> /dev/null || echo docker)
+SUPPORTED_ENGINES := docker podman
+engine_arg := $(filter $(SUPPORTED_ENGINES),$(MAKECMDGOALS))
+ifneq ($(engine_arg),)
+  CONTAINER_ENGINE = $(word 1,$(engine_arg))
+  $(eval $(engine_arg):;@:)
+else
+  CONTAINER_ENGINE ?= $(shell command -v podman 2> /dev/null || command -v docker 2> /dev/null || echo docker)
+endif
 
 CPUPROFILE ?= cpu.prof
 MEMPROFILE ?= mem.prof
 WATCH_TARGET ?= run
+BUILD_CPU_LIMIT ?= 2
+
+# CPU limits and Users are handled differently in Podman and Docker
+ifeq ($(findstring podman,$(CONTAINER_ENGINE)),podman)
+    # Rootless Podman often lacks cgroup delegation for cpuset/cpu quotas.
+    # We omit the limit by default to avoid crun/cgroupv2 errors.
+    CPU_LIMIT_ARGS ?=
+    # Podman requires --userns=keep-id to map current user nicely without file permission issues
+    USER_ARGS ?= --userns=keep-id -e HOME=/
+else
+    CPU_LIMIT_ARGS ?= --cpus $(BUILD_CPU_LIMIT)
+    # Docker uses the simple uid flag
+    USER_ARGS ?= -u "$(UID)" -e HOME=/
+endif
 
 ## File Lists
 goFiles := $(shell find . -iname "*.go" -type f | grep -v "/_" | grep -v "^\./vendor")
@@ -56,19 +82,19 @@ air: ## Run Air for live reloading
 
 .PHONY: build-docker
 build-docker: ## Build container image
-	$(CONTAINER_ENGINE) build -t $(DOCKER_IMAGE) .
+	$(CONTAINER_ENGINE) build $(CPU_LIMIT_ARGS) -t $(DOCKER_IMAGE) .
 
 build-docker-debug: ## Build container image for debugging
-	$(CONTAINER_ENGINE) build --target debug -t $(DOCKER_IMAGE):debug .
+	$(CONTAINER_ENGINE) build $(CPU_LIMIT_ARGS) --target debug -t $(DOCKER_IMAGE):debug .
 
 build-docker-dev: ## Build container image for development
-	$(CONTAINER_ENGINE) build -f dev.Dockerfile -t $(DOCKER_IMAGE):dev .
+	$(CONTAINER_ENGINE) build $(CPU_LIMIT_ARGS) -f dev.Dockerfile -t $(DOCKER_IMAGE):dev .
 
 dev-env: ## Run development environment in container
 	@if ! $(CONTAINER_ENGINE) image inspect $(DOCKER_IMAGE):dev > /dev/null 2>&1; then \
 		$(MAKE) build-docker-dev; \
 	fi
-	$(CONTAINER_ENGINE) run --rm -it --network host -u "$(UID)" --env-file "$(ENV_FILE)" \
+	$(CONTAINER_ENGINE) run --rm -it --network host $(USER_ARGS) --env-file "$(ENV_FILE)" \
 		-v "$$HOME/.cache:/.cache:Z" -v "$$HOME/go/pkg:/go/pkg:Z" -v .:/src:Z \
 		$(DOCKER_IMAGE):dev
 

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,9 @@ UID ?= $(shell id -u)
 GODOC_PORT ?= 6060
 ENV_FILE ?= .env
 
+# Container engine detection
+CONTAINER_ENGINE ?= $(shell command -v podman 2> /dev/null || command -v docker 2> /dev/null || echo docker)
+
 CPUPROFILE ?= cpu.prof
 MEMPROFILE ?= mem.prof
 WATCH_TARGET ?= run
@@ -48,25 +51,25 @@ run-race: ## Run the application with race detector
 air: ## Run Air for live reloading
 	$(GOPATH)/bin/air
 
-##@ Docker
+##@ Container Support (Docker/Podman)
 .PHONY: build-docker build-docker-debug build-docker-dev dev-env
 
 .PHONY: build-docker
-build-docker: ## Build Docker image
-	docker build -t $(DOCKER_IMAGE) .
+build-docker: ## Build container image
+	$(CONTAINER_ENGINE) build -t $(DOCKER_IMAGE) .
 
-build-docker-debug: ## Build Docker image for debugging
-	docker build --target debug -t $(DOCKER_IMAGE):debug .
+build-docker-debug: ## Build container image for debugging
+	$(CONTAINER_ENGINE) build --target debug -t $(DOCKER_IMAGE):debug .
 
-build-docker-dev: ## Build Docker image for development
-	docker build -f dev.Dockerfile -t $(DOCKER_IMAGE):dev .
+build-docker-dev: ## Build container image for development
+	$(CONTAINER_ENGINE) build -f dev.Dockerfile -t $(DOCKER_IMAGE):dev .
 
-dev-env: ## Run development environment in Docker
-	@if ! docker image inspect $(DOCKER_IMAGE):dev > /dev/null 2>&1; then \
+dev-env: ## Run development environment in container
+	@if ! $(CONTAINER_ENGINE) image inspect $(DOCKER_IMAGE):dev > /dev/null 2>&1; then \
 		$(MAKE) build-docker-dev; \
 	fi
-	docker run --rm -it --network host -u "$(UID)" --env-file "$(ENV_FILE)" \
-		-v "$$HOME/.cache:/.cache" -v "$$HOME/go/pkg:/go/pkg" -v .:/src \
+	$(CONTAINER_ENGINE) run --rm -it --network host -u "$(UID)" --env-file "$(ENV_FILE)" \
+		-v "$$HOME/.cache:/.cache:Z" -v "$$HOME/go/pkg:/go/pkg:Z" -v .:/src:Z \
 		$(DOCKER_IMAGE):dev
 
 ##@ Testing

--- a/README.md
+++ b/README.md
@@ -63,6 +63,20 @@ export PATH="$(go env "GOPATH")/bin:$PATH"
 TELEGRAM_APITOKEN="YOUR_BOT_TOKEN" adan-bot
 ```
 
+### Using Containers (Docker or Podman)
+
+The project includes a `Makefile` that automatically detects if you have `podman` or `docker` installed.
+
+To build the image:
+```shell
+make build-docker
+```
+
+To run a development environment with live reloading (using `air`):
+```shell
+make dev-env
+```
+
 ## Features
 
 - [x] Hola Mundo.
@@ -86,6 +100,7 @@ TELEGRAM_APITOKEN="YOUR_BOT_TOKEN" adan-bot
 - [![Go][Go]][Go-url]
 - [![telegram-api][telegram-api]][telegram-api-url]
 - [![Docker][Docker-shield]][Docker-url]
+- [![Podman][Podman-shield]][Podman-url]
 
 [Go]: https://img.shields.io/badge/Go-3498DB?style=flat&logo=Go&logoColor=white
 [Go-url]: https://go.dev/
@@ -94,6 +109,8 @@ TELEGRAM_APITOKEN="YOUR_BOT_TOKEN" adan-bot
 [codeQL-shield]: https://github.com/ossf/scorecard/workflows/CodeQL/badge.svg?branch=main
 [Docker-shield]: https://img.shields.io/badge/docker-003f8c?style=flat&logo=docker&logoColor=white
 [Docker-url]: https://www.docker.com/
+[Podman-shield]: https://img.shields.io/badge/podman-892ca0?style=flat&logo=podman&logoColor=white
+[Podman-url]: https://podman.io/
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -65,17 +65,41 @@ TELEGRAM_APITOKEN="YOUR_BOT_TOKEN" adan-bot
 
 ### Using Containers (Docker or Podman)
 
-The project includes a `Makefile` that automatically detects if you have `podman` or `docker` installed.
+The project includes a `Makefile` that automatically detects if you have `podman` or `docker` installed. If you have both, Podman takes precedence.
+You can also explicitly specify the engine by appending `docker` or `podman` after your target.
 
-To build the image:
+To build the image (with auto-detection):
 ```shell
 make build-docker
+```
+Or specifying the engine:
+```shell
+make build-docker docker
 ```
 
 To run a development environment with live reloading (using `air`):
 ```shell
-make dev-env
+make dev-env podman
 ```
+
+> [!TIP]
+> Build-time options such as the CPU limit are read from your `.env` file automatically — no extra flags needed. See [Environment configuration](#environment-configuration) below.
+
+## Environment configuration
+
+Copy `env.example` to `.env` and fill in the values:
+
+```shell
+cp env.example .env
+```
+
+| Variable | Required | Default | Description |
+|---|---|---|---|
+| `TELEGRAM_API_TOKEN` | ✅ | — | Bot token obtained from [@BotFather](https://t.me/botfather) |
+| `BUILD_CPU_LIMIT` | ❌ | `2` | Max CPUs the container engine may use **while building** an image. Accepts decimals (`1.5`). Set to `0` to remove the limit. |
+
+> [!NOTE]
+> The `.env` file is listed in `.gitignore` and will never be committed. `env.example` is the safe, version-controlled template.
 
 ## Features
 

--- a/env.example
+++ b/env.example
@@ -1,0 +1,9 @@
+# ── Bot ────────────────────────────────────────────────────────────────────────
+# Telegram bot API token (required).
+TELEGRAM_API_TOKEN="YOUR_BOT_TOKEN_HERE"
+
+# ── Container build ────────────────────────────────────────────────────────────
+# Number of CPUs available to the container engine during image builds.
+# Accepts decimals (e.g. 1.5). Set to 0 to remove the limit entirely.
+# Default: 2
+BUILD_CPU_LIMIT=2


### PR DESCRIPTION
This pull request introduces official support for Podman as an alternative to Docker for local development and build processes. It refactors the existing `Makefile` to automatically detect the available container engine and ensures volume compatibility for SELinux-enabled systems.
### Key Changes
- **Makefile Refactoring**:
  - Added a `CONTAINER_ENGINE` variable with auto-detection logic (prioritizing `podman` over `docker` if both are present).
  - Replaced all hardcoded `docker` commands with `$(CONTAINER_ENGINE)` across all development and build targets.
  - Added the `:Z` flag to volume mounts in the `dev-env` target to ensure compatibility with Podman rootless on SELinux systems (Fedora, RHEL, CentOS, etc.).
  - Renamed the Docker section to **Container Support (Docker/Podman)** for better clarity.
- **Documentation Updates**:
  - Updated `README.md` with a new section on how to build and run the project using either Docker or Podman.
  - Added a Podman shield to the "Built With" section.
### Verification
- Verified `make help` output to confirm correct target categorization.
- Validated that the `CONTAINER_ENGINE` variable can be manually overridden if needed (e.g., `make build-docker CONTAINER_ENGINE=docker`).

Fixes: #37 