### PR TITLE
feat: implement community birthdays and daily greetings scheduler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -185,3 +185,8 @@ tmp/*
 reports
 adan-bot
 
+
+# Local data for db
+local.db
+
+

--- a/Makefile
+++ b/Makefile
@@ -112,9 +112,11 @@ ifneq "$(notdir $(TARGET_PKG))" "..."
 endif
 
 test: ## Run tests
+	@mkdir -p $(dir $(COVERAGE_FILE))
 	@$(GO) test -v -run "$(TARGET_FUNC)" -coverprofile "$(COVERAGE_FILE)" $(profileFlags) "$(TARGET_PKG)"
 
 test-race: ## Run tests with race detector
+	@mkdir -p $(dir $(COVERAGE_FILE))
 	@$(GO) test -v -race -run "$(TARGET_FUNC)" -coverprofile "$(COVERAGE_FILE)" $(profileFlags) "$(TARGET_PKG)"
 
 ##@ Benchmarking

--- a/cmd/adan-bot/main.go
+++ b/cmd/adan-bot/main.go
@@ -15,6 +15,8 @@ import (
 
 	"github.com/Golang-Venezuela/adan-bot/internal/adapters/delivery/telegram"
 	"github.com/Golang-Venezuela/adan-bot/internal/adapters/repository"
+	sqlite "github.com/Golang-Venezuela/adan-bot/internal/adapters/repository/sqlite"
+	"github.com/Golang-Venezuela/adan-bot/internal/core/ports"
 	"github.com/Golang-Venezuela/adan-bot/internal/core/services"
 	"github.com/Golang-Venezuela/adan-bot/internal/infra/config"
 	"github.com/Golang-Venezuela/adan-bot/internal/infra/logger"
@@ -64,10 +66,22 @@ func Main() error {
 
 	slog.Info("Authorized", slog.String("account", logger.Obfuscate(bot.Me.Username)))
 
+	// Initialize Database dependencies
+	dbUrl := config.Getenv("TURSO_DB_URL", "file:local.db")
+	userRepo, err := sqlite.NewUserRepository(dbUrl)
+	if err != nil {
+		return fmt.Errorf("cannot initialize database: %w", err)
+	}
+	botSvc := services.NewBotService(userRepo)
+	telegram.RegisterHandlers(bot, botSvc)
+
 	// Initialize Moderation dependencies
 	modRepo := repository.NewMemoryModerationRepo()
 	modSvc := services.NewModerationService(modRepo)
 	telegram.RegisterModerationHandlers(bot, modSvc)
+
+	// Start background birthday scheduler
+	startBirthdayScheduler(bot, botSvc)
 
 	// Inject a global middleware to intercept and log incoming messages for tracing and observability.
 	bot.Use(func(next tele.HandlerFunc) tele.HandlerFunc {
@@ -156,4 +170,54 @@ func main() {
 		slog.Error("Fatal runtime error exiting", slog.Any("error", err))
 		os.Exit(1)
 	}
+}
+
+// startBirthdayScheduler runs a background worker that checks birthdays daily.
+func startBirthdayScheduler(bot *tele.Bot, svc ports.BotService) {
+	chatIDStr := config.Getenv("TELEGRAM_GROUP_CHAT_ID", "")
+	if chatIDStr == "" {
+		slog.Warn("TELEGRAM_GROUP_CHAT_ID is not configured; birthday announcements will not be sent")
+		return
+	}
+
+	var chatID int64
+	if _, err := fmt.Sscan(chatIDStr, &chatID); err != nil {
+		slog.Error("Invalid TELEGRAM_GROUP_CHAT_ID format", slog.String("value", chatIDStr), slog.Any("error", err))
+		return
+	}
+
+	go func() {
+		loc, err := time.LoadLocation("America/Caracas")
+		if err != nil {
+			loc = time.UTC
+		}
+
+		for {
+			now := time.Now().In(loc)
+			nextRun := time.Date(now.Year(), now.Month(), now.Day(), 8, 0, 0, 0, loc)
+			if now.After(nextRun) {
+				nextRun = nextRun.Add(24 * time.Hour)
+			}
+
+			duration := time.Until(nextRun)
+			slog.Info("Birthday scheduler scheduled next check", slog.Time("next_run", nextRun), slog.Duration("wait_duration", duration))
+
+			time.Sleep(duration)
+
+			ctx := context.Background()
+			msg, err := svc.HandleTodayBirthdays(ctx)
+			if err != nil {
+				slog.Error("Error checking today's birthdays in scheduler", slog.Any("error", err))
+				continue
+			}
+
+			if msg != "" {
+				slog.Info("Sending daily birthday congratulations message")
+				_, err = bot.Send(&tele.Chat{ID: chatID}, msg, tele.ModeHTML)
+				if err != nil {
+					slog.Error("Failed to send birthday greetings message", slog.Any("error", err))
+				}
+			}
+		}
+	}()
 }

--- a/cmd/serverless-aws/main.go
+++ b/cmd/serverless-aws/main.go
@@ -6,6 +6,7 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"log/slog"
 	"net/http"
 	"strings"
@@ -67,6 +68,44 @@ func init() {
 	// and triggers synchronous processing. We avoid using bot.Start() or tele.Webhook
 	// because the standard Poller initializes channels and goroutines that are not well-suited for Lambda.
 	botHandler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Trigger endpoint for daily birthdays check (e.g. AWS API Gateway trigger from cron)
+		if r.URL.Path == "/tasks/check-birthdays" {
+			chatIDStr := config.Getenv("TELEGRAM_GROUP_CHAT_ID", "")
+			if chatIDStr == "" {
+				slog.Error("TELEGRAM_GROUP_CHAT_ID is not configured")
+				http.Error(w, "Group chat ID not configured", http.StatusInternalServerError)
+				return
+			}
+			var chatID int64
+			if _, err := fmt.Sscan(chatIDStr, &chatID); err != nil {
+				slog.Error("Invalid TELEGRAM_GROUP_CHAT_ID format", slog.Any("error", err))
+				http.Error(w, "Invalid Group Chat ID configuration", http.StatusInternalServerError)
+				return
+			}
+
+			slog.Info("Triggering serverless birthday check")
+			msg, err := botSvc.HandleTodayBirthdays(context.Background())
+			if err != nil {
+				slog.Error("Error checking birthdays in serverless handler", slog.Any("error", err))
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+				return
+			}
+
+			if msg != "" {
+				slog.Info("Sending serverless daily birthday congratulations message")
+				_, err = bot.Send(&tele.Chat{ID: chatID}, msg, tele.ModeHTML)
+				if err != nil {
+					slog.Error("Failed to send serverless birthday greetings message", slog.Any("error", err))
+					http.Error(w, err.Error(), http.StatusInternalServerError)
+					return
+				}
+			}
+
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte("Birthdays checked successfully"))
+			return
+		}
+
 		var update tele.Update
 		if err := json.NewDecoder(r.Body).Decode(&update); err != nil {
 			slog.Error("Could not decode update", slog.Any("error", err))

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,8 @@ require github.com/joho/godotenv v1.5.1
 require (
 	github.com/aws/aws-lambda-go v1.54.0
 	github.com/awslabs/aws-lambda-go-api-proxy v0.16.2
+	github.com/jmoiron/sqlx v1.4.0
+	github.com/mattn/go-sqlite3 v1.14.47
 	github.com/tursodatabase/libsql-client-go v0.0.0-20251219100830-236aa1ff8acc
 	gopkg.in/telebot.v4 v4.0.0-beta.10
 )

--- a/go.sum
+++ b/go.sum
@@ -54,6 +54,8 @@ cloud.google.com/go/storage v1.8.0/go.mod h1:Wv1Oy7z6Yz3DshWRJFhqM/UCfaWIRTdp0RX
 cloud.google.com/go/storage v1.10.0/go.mod h1:FLPqc6j+Ki4BU591ie1oL6qBQGu2Bl/tZ9ullr3+Kg0=
 cloud.google.com/go/storage v1.14.0/go.mod h1:GrKmX003DSIwi9o29oFT7YDnHYwZoctc3fOKtUw0Xmo=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
+filippo.io/edwards25519 v1.1.0 h1:FNf4tywRC1HmFuKW5xopWpigGjJKiJSV0Cqo0cJWDaA=
+filippo.io/edwards25519 v1.1.0/go.mod h1:BxyFTGdWcka3PhytdK4V28tE5sGfRvvvRV7EaN4VDT4=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/DataDog/datadog-go v3.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
@@ -138,6 +140,8 @@ github.com/go-playground/assert/v2 v2.0.1/go.mod h1:VDjEfimB/XKnb+ZQfWdccd7VUvSc
 github.com/go-playground/locales v0.13.0/go.mod h1:taPMhCMXrRLJO55olJkUXHZBHCxTMfnGwq/HNwmWNS8=
 github.com/go-playground/universal-translator v0.17.0/go.mod h1:UkSxE5sNxxRwHyU+Scu5vgOQjsIJAF8j9muTVoKLVtA=
 github.com/go-playground/validator/v10 v10.4.1/go.mod h1:nlOn6nFhuKACm19sB/8EGNn9GlaMV7XkbRSipzJ0Ii4=
+github.com/go-sql-driver/mysql v1.8.1 h1:LedoTUt/eveggdHS9qUFC1EFSa8bU2+1pZjSRpvNJ1Y=
+github.com/go-sql-driver/mysql v1.8.1/go.mod h1:wEBSXgmK//2ZFJyE+qWnIsVGmvmEKlqwuVSjsCm7DZg=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/goccy/go-yaml v1.9.5/go.mod h1:U/jl18uSupI5rdI2jmuCswEA2htH9eXfferR3KfscvA=
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
@@ -255,6 +259,8 @@ github.com/hashicorp/serf v0.9.6/go.mod h1:TXZNMjZQijwlDvp+r0b63xZ45H7JmCmgg4gpT
 github.com/hashicorp/serf v0.9.7/go.mod h1:TXZNMjZQijwlDvp+r0b63xZ45H7JmCmgg4gpTwn9UV4=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
+github.com/jmoiron/sqlx v1.4.0 h1:1PLqN7S1UYp5t4SrVVnt4nUVNemrDAtxlulVe+Qgm3o=
+github.com/jmoiron/sqlx v1.4.0/go.mod h1:ZrZ7UsYB/weZdl2Bxg6jCRO9c3YHl8r3ahlKmRT4JLY=
 github.com/joho/godotenv v1.5.1 h1:7eLL/+HRGLY0ldzfGMeQkb7vMd0as4CfYvUVzLqw0N0=
 github.com/joho/godotenv v1.5.1/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwAbqwq4=
 github.com/jpillora/backoff v1.0.0/go.mod h1:J/6gKK9jxlEcS3zixgDgUAsiuZ7yrSoa/FX5e0EB2j4=
@@ -280,6 +286,8 @@ github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
 github.com/leodido/go-urn v1.2.0/go.mod h1:+8+nEpDfqqsY+g338gtMEUOtuK+4dEMhiQEgxpxOKII=
+github.com/lib/pq v1.10.9 h1:YXG7RB+JIjhP29X+OtkiDnYaXQwpS4JEWq7dtCCRUEw=
+github.com/lib/pq v1.10.9/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
 github.com/magiconair/properties v1.8.6/go.mod h1:y3VJvCyxH9uVvJTWEGAELF3aiYNyPKd5NZ3oSwXrF60=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
 github.com/mattn/go-colorable v0.1.4/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
@@ -293,6 +301,9 @@ github.com/mattn/go-isatty v0.0.10/go.mod h1:qgIWMr58cqv1PHHyhnkY9lrL7etaEgOFcME
 github.com/mattn/go-isatty v0.0.11/go.mod h1:PhnuNfih5lzO57/f3n+odYbM4JtupLOxQOAqxQCu2WE=
 github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
 github.com/mattn/go-isatty v0.0.14/go.mod h1:7GGIvUiUoEMVVmxf/4nioHXj79iQHKdU27kJ6hsGG94=
+github.com/mattn/go-sqlite3 v1.14.22/go.mod h1:Uh1q+B4BYcTPb+yiD3kU8Ct7aC0hY9fxUwlHK0RXw+Y=
+github.com/mattn/go-sqlite3 v1.14.47 h1:jOBI62gS7nKeZv+as1oGEy0+1qISgXwH/QBlR6KbfIo=
+github.com/mattn/go-sqlite3 v1.14.47/go.mod h1:6JTjA44L93a0QCyJef5YvlPoKXntQPjzWv5gtm9sB6w=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/miekg/dns v1.1.26/go.mod h1:bPDLeHnStXmXAq1m/Ch/hvfNHr14JKNPMBo3VZKjuso=
 github.com/miekg/dns v1.1.41/go.mod h1:p6aan82bvRIyn+zDIv9xYNUpwa73JcSh9BKwknJysuI=

--- a/internal/adapters/delivery/telegram/router.go
+++ b/internal/adapters/delivery/telegram/router.go
@@ -43,6 +43,47 @@ func RegisterHandlers(bot *tele.Bot, svc ports.BotService) {
 		return c.Send(svc.HandleStatus(ctx))
 	})
 
+	bot.Handle("/micumple", func(c tele.Context) error {
+		ctx := context.Background()
+		userID := c.Sender().ID
+		args := c.Args()
+		if len(args) == 0 {
+			return c.Send("Por favor ingresa tu fecha de cumpleaños en formato DD/MM.\nEjemplo: `/micumple 15/10`", tele.ModeMarkdown)
+		}
+
+		dateStr := args[0]
+		slog.Info("Executing /micumple", slog.String("user_id", logger.ObfuscateID(userID)), slog.String("date", dateStr))
+
+		msg, err := svc.HandleSetBirthday(ctx, userID, dateStr)
+		if err != nil {
+			slog.Error("Error in HandleSetBirthday", slog.Any("error", err))
+		}
+		return c.Send(msg)
+	})
+
+	bot.Handle("/borrarcumple", func(c tele.Context) error {
+		ctx := context.Background()
+		userID := c.Sender().ID
+		slog.Info("Executing /borrarcumple", slog.String("user_id", logger.ObfuscateID(userID)))
+
+		msg, err := svc.HandleRemoveBirthday(ctx, userID)
+		if err != nil {
+			slog.Error("Error in HandleRemoveBirthday", slog.Any("error", err))
+		}
+		return c.Send(msg)
+	})
+
+	bot.Handle("/cumples_mes", func(c tele.Context) error {
+		ctx := context.Background()
+		slog.Info("Executing /cumples_mes")
+
+		msg, err := svc.HandleGetBirthdaysOfMonth(ctx)
+		if err != nil {
+			slog.Error("Error in HandleGetBirthdaysOfMonth", slog.Any("error", err))
+		}
+		return c.Send(msg, tele.ModeHTML)
+	})
+
 	// Fallback handler for unmapped textual commands.
 	bot.Handle(tele.OnText, func(c tele.Context) error {
 		if strings.HasPrefix(c.Text(), "/") {

--- a/internal/adapters/repository/sqlite/user_repo.go
+++ b/internal/adapters/repository/sqlite/user_repo.go
@@ -10,12 +10,14 @@ import (
 
 	"github.com/Golang-Venezuela/adan-bot/internal/core/domain"
 	"github.com/Golang-Venezuela/adan-bot/internal/infra/logger"
+	"github.com/jmoiron/sqlx"
+	_ "github.com/mattn/go-sqlite3"
 	_ "github.com/tursodatabase/libsql-client-go/libsql" // Driver compatible with local SQLite and Turso
 )
 
 // userRepo represents the SQLite-backed user repository implementing the domain ports.
 type userRepo struct {
-	db *sql.DB
+	db *sqlx.DB
 }
 
 // NewUserRepository establishes a database connection and creates the target schema if it does not exist.
@@ -26,6 +28,8 @@ func NewUserRepository(dbUrl string) (*userRepo, error) {
 		return nil, fmt.Errorf("error opening db: %w", err)
 	}
 
+	dbx := sqlx.NewDb(db, "libsql")
+
 	// Create base table if it doesn't already exist.
 	query := `
 	CREATE TABLE IF NOT EXISTS users (
@@ -33,29 +37,38 @@ func NewUserRepository(dbUrl string) (*userRepo, error) {
 		username TEXT,
 		first_name TEXT,
 		last_name TEXT,
+		birthday_day INTEGER,
+		birthday_month INTEGER,
 		created_at DATETIME DEFAULT CURRENT_TIMESTAMP
 	);`
 
-	if _, err := db.ExecContext(context.Background(), query); err != nil {
+	if _, err := dbx.ExecContext(context.Background(), query); err != nil {
 		slog.Error("error creating users table", slog.Any("error", err))
+		db.Close()
 		return nil, fmt.Errorf("error creating users table: %w", err)
 	}
 
-	return &userRepo{db: db}, nil
+	// Run migration steps to add birthday columns if they don't exist in an existing database
+	_, _ = dbx.ExecContext(context.Background(), "ALTER TABLE users ADD COLUMN birthday_day INTEGER;")
+	_, _ = dbx.ExecContext(context.Background(), "ALTER TABLE users ADD COLUMN birthday_month INTEGER;")
+
+	return &userRepo{db: dbx}, nil
 }
 
 // SaveUser inserts a newly authenticated user into the database or updates their current profile
 // if their Telegram ID already exists, enabling deterministic user synchronization.
 func (r *userRepo) SaveUser(ctx context.Context, u domain.User) error {
 	query := `
-		INSERT INTO users (id, username, first_name, last_name, created_at)
-		VALUES (?, ?, ?, ?, ?)
+		INSERT INTO users (id, username, first_name, last_name, birthday_day, birthday_month, created_at)
+		VALUES (:id, :username, :first_name, :last_name, :birthday_day, :birthday_month, :created_at)
 		ON CONFLICT(id) DO UPDATE SET 
 			username = excluded.username,
 			first_name = excluded.first_name,
-			last_name = excluded.last_name;
+			last_name = excluded.last_name,
+			birthday_day = COALESCE(excluded.birthday_day, users.birthday_day),
+			birthday_month = COALESCE(excluded.birthday_month, users.birthday_month);
 	`
-	_, err := r.db.ExecContext(ctx, query, u.ID, u.Username, u.FirstName, u.LastName, u.CreatedAt)
+	_, err := r.db.NamedExecContext(ctx, query, u)
 	if err != nil {
 		slog.Error("error saving user", slog.Any("error", err), slog.String("user_id", logger.ObfuscateID(u.ID)))
 		return fmt.Errorf("error saving user: %w", err)
@@ -70,11 +83,9 @@ func (r *userRepo) SaveUser(ctx context.Context, u domain.User) error {
 // It returns nil, nil when the user is not found to prevent masking valid non-existences as SQL errors.
 func (r *userRepo) GetUserByID(ctx context.Context, id int64) (*domain.User, error) {
 	var u domain.User
-	query := `SELECT id, username, first_name, last_name, created_at FROM users WHERE id = ?`
+	query := `SELECT id, username, first_name, last_name, birthday_day, birthday_month, created_at FROM users WHERE id = ?`
 
-	err := r.db.QueryRowContext(ctx, query, id).Scan(
-		&u.ID, &u.Username, &u.FirstName, &u.LastName, &u.CreatedAt,
-	)
+	err := r.db.GetContext(ctx, &u, query, id)
 	if err != nil {
 		if err == sql.ErrNoRows {
 			slog.Debug("User not found", slog.String("user_id", logger.ObfuscateID(id)))
@@ -86,4 +97,54 @@ func (r *userRepo) GetUserByID(ctx context.Context, id int64) (*domain.User, err
 
 	slog.Debug("User retrieved successfully", slog.String("user_id", logger.ObfuscateID(id)))
 	return &u, nil
+}
+
+// SetBirthday sets the birthday (day and month) for a specific user ID.
+func (r *userRepo) SetBirthday(ctx context.Context, userID int64, day, month int) error {
+	query := `UPDATE users SET birthday_day = ?, birthday_month = ? WHERE id = ?`
+	_, err := r.db.ExecContext(ctx, query, day, month, userID)
+	if err != nil {
+		slog.Error("error setting birthday", slog.Any("error", err), slog.String("user_id", logger.ObfuscateID(userID)))
+		return fmt.Errorf("error setting birthday: %w", err)
+	}
+
+	slog.Debug("Birthday updated successfully", slog.String("user_id", logger.ObfuscateID(userID)))
+	return nil
+}
+
+// RemoveBirthday clears the birthday fields for a specific user ID.
+func (r *userRepo) RemoveBirthday(ctx context.Context, userID int64) error {
+	query := `UPDATE users SET birthday_day = NULL, birthday_month = NULL WHERE id = ?`
+	_, err := r.db.ExecContext(ctx, query, userID)
+	if err != nil {
+		slog.Error("error removing birthday", slog.Any("error", err), slog.String("user_id", logger.ObfuscateID(userID)))
+		return fmt.Errorf("error removing birthday: %w", err)
+	}
+
+	slog.Debug("Birthday removed successfully", slog.String("user_id", logger.ObfuscateID(userID)))
+	return nil
+}
+
+// GetBirthdaysByDayAndMonth retrieves all users who celebrate their birthday on a specific day and month.
+func (r *userRepo) GetBirthdaysByDayAndMonth(ctx context.Context, day, month int) ([]domain.User, error) {
+	var users []domain.User
+	query := `SELECT id, username, first_name, last_name, birthday_day, birthday_month, created_at FROM users WHERE birthday_day = ? AND birthday_month = ?`
+	err := r.db.SelectContext(ctx, &users, query, day, month)
+	if err != nil {
+		slog.Error("error getting birthdays by day and month", slog.Any("error", err), slog.Int("day", day), slog.Int("month", month))
+		return nil, fmt.Errorf("error getting birthdays by day and month: %w", err)
+	}
+	return users, nil
+}
+
+// GetBirthdaysByMonth retrieves all users who celebrate their birthday in a specific month.
+func (r *userRepo) GetBirthdaysByMonth(ctx context.Context, month int) ([]domain.User, error) {
+	var users []domain.User
+	query := `SELECT id, username, first_name, last_name, birthday_day, birthday_month, created_at FROM users WHERE birthday_month = ?`
+	err := r.db.SelectContext(ctx, &users, query, month)
+	if err != nil {
+		slog.Error("error getting birthdays by month", slog.Any("error", err), slog.Int("month", month))
+		return nil, fmt.Errorf("error getting birthdays by month: %w", err)
+	}
+	return users, nil
 }

--- a/internal/adapters/repository/sqlite/user_repo_test.go
+++ b/internal/adapters/repository/sqlite/user_repo_test.go
@@ -1,0 +1,130 @@
+package sqlite
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/Golang-Venezuela/adan-bot/internal/core/domain"
+	_ "github.com/mattn/go-sqlite3"
+)
+
+func TestUserRepository_SQLite(t *testing.T) {
+	ctx := context.Background()
+
+	// Use an in-memory sqlite database for testing
+	repo, err := NewUserRepository("file::memory:?cache=shared")
+	if err != nil {
+		t.Fatalf("failed to initialize repository: %v", err)
+	}
+	defer repo.db.DB.Close()
+
+	// Test 1: SaveUser and GetUserByID
+	user := domain.User{
+		ID:        999,
+		Username:  "gopher_venezuela",
+		FirstName: "Gopher",
+		LastName:  "VZLA",
+		CreatedAt: time.Now().Round(time.Second),
+	}
+
+	err = repo.SaveUser(ctx, user)
+	if err != nil {
+		t.Fatalf("failed to save user: %v", err)
+	}
+
+	got, err := repo.GetUserByID(ctx, 999)
+	if err != nil {
+		t.Fatalf("failed to get user by id: %v", err)
+	}
+
+	if got == nil {
+		t.Fatal("expected user to be found, got nil")
+	}
+
+	if got.Username != user.Username || got.FirstName != user.FirstName || got.LastName != user.LastName {
+		t.Errorf("GetUserByID() = %+v, want %+v", got, user)
+	}
+
+	// Test 2: GetUserByID not found
+	gotNotFound, err := repo.GetUserByID(ctx, 9999)
+	if err != nil {
+		t.Fatalf("unexpected error getting non-existent user: %v", err)
+	}
+	if gotNotFound != nil {
+		t.Errorf("expected nil for non-existent user, got %+v", gotNotFound)
+	}
+
+	// Test 3: SaveUser updates profile on conflict (keeps birthday nil)
+	user.FirstName = "NewName"
+	err = repo.SaveUser(ctx, user)
+	if err != nil {
+		t.Fatalf("failed to update user: %v", err)
+	}
+	gotUpdated, _ := repo.GetUserByID(ctx, 999)
+	if gotUpdated.FirstName != "NewName" {
+		t.Errorf("expected first name to be updated, got %q", gotUpdated.FirstName)
+	}
+	if gotUpdated.BirthdayDay != nil || gotUpdated.BirthdayMonth != nil {
+		t.Errorf("expected birthday to remain nil")
+	}
+
+	// Test 4: SetBirthday and GetBirthdaysByDayAndMonth
+	err = repo.SetBirthday(ctx, 999, 24, 7)
+	if err != nil {
+		t.Fatalf("failed to set birthday: %v", err)
+	}
+
+	gotBday, _ := repo.GetUserByID(ctx, 999)
+	if gotBday.BirthdayDay == nil || *gotBday.BirthdayDay != 24 || gotBday.BirthdayMonth == nil || *gotBday.BirthdayMonth != 7 {
+		t.Errorf("birthday not set correctly in user record: %+v", gotBday)
+	}
+
+	// Test 5: GetBirthdaysByDayAndMonth filter
+	bdayUsers, err := repo.GetBirthdaysByDayAndMonth(ctx, 24, 7)
+	if err != nil {
+		t.Fatalf("failed to get birthdays by day and month: %v", err)
+	}
+	if len(bdayUsers) != 1 || bdayUsers[0].ID != 999 {
+		t.Errorf("expected 1 birthday user with ID 999, got %v", bdayUsers)
+	}
+
+	// Non-matching day
+	emptyBdayUsers, _ := repo.GetBirthdaysByDayAndMonth(ctx, 25, 7)
+	if len(emptyBdayUsers) != 0 {
+		t.Errorf("expected 0 birthday users, got %v", emptyBdayUsers)
+	}
+
+	// Test 6: GetBirthdaysByMonth
+	monthUsers, err := repo.GetBirthdaysByMonth(ctx, 7)
+	if err != nil {
+		t.Fatalf("failed to get birthdays by month: %v", err)
+	}
+	if len(monthUsers) != 1 || monthUsers[0].ID != 999 {
+		t.Errorf("expected 1 user in month 7, got %v", monthUsers)
+	}
+
+	// Test 7: SaveUser on conflict does not wipe out birthday (COALESCE check)
+	user.LastName = "UpdatedLastName"
+	err = repo.SaveUser(ctx, user)
+	if err != nil {
+		t.Fatalf("failed to save user: %v", err)
+	}
+	gotAfterSave, _ := repo.GetUserByID(ctx, 999)
+	if gotAfterSave.LastName != "UpdatedLastName" {
+		t.Errorf("expected last name to update, got %q", gotAfterSave.LastName)
+	}
+	if gotAfterSave.BirthdayDay == nil || *gotAfterSave.BirthdayDay != 24 {
+		t.Errorf("expected birthday to be preserved, got nil or wrong day")
+	}
+
+	// Test 8: RemoveBirthday
+	err = repo.RemoveBirthday(ctx, 999)
+	if err != nil {
+		t.Fatalf("failed to remove birthday: %v", err)
+	}
+	gotRemoved, _ := repo.GetUserByID(ctx, 999)
+	if gotRemoved.BirthdayDay != nil || gotRemoved.BirthdayMonth != nil {
+		t.Errorf("expected birthday fields to be nil after removal, got %v / %v", gotRemoved.BirthdayDay, gotRemoved.BirthdayMonth)
+	}
+}

--- a/internal/core/domain/user.go
+++ b/internal/core/domain/user.go
@@ -4,9 +4,11 @@ import "time"
 
 // User representa a un usuario que interactúa con el bot
 type User struct {
-	ID        int64
-	Username  string
-	FirstName string
-	LastName  string
-	CreatedAt time.Time
+	ID            int64     `db:"id"`
+	Username      string    `db:"username"`
+	FirstName     string    `db:"first_name"`
+	LastName      string    `db:"last_name"`
+	BirthdayDay   *int      `db:"birthday_day"`
+	BirthdayMonth *int      `db:"birthday_month"`
+	CreatedAt     time.Time `db:"created_at"`
 }

--- a/internal/core/ports/ports.go
+++ b/internal/core/ports/ports.go
@@ -15,6 +15,10 @@ import (
 type UserRepository interface {
 	SaveUser(ctx context.Context, user domain.User) error
 	GetUserByID(ctx context.Context, id int64) (*domain.User, error)
+	SetBirthday(ctx context.Context, userID int64, day, month int) error
+	RemoveBirthday(ctx context.Context, userID int64) error
+	GetBirthdaysByDayAndMonth(ctx context.Context, day, month int) ([]domain.User, error)
+	GetBirthdaysByMonth(ctx context.Context, month int) ([]domain.User, error)
 }
 
 // BotService defines the core business operations and use cases for the Adan Bot.
@@ -23,6 +27,10 @@ type BotService interface {
 	HandleStartHelp(ctx context.Context) string
 	HandleHola(ctx context.Context, userID int64, username, firstName, lastName string) (string, error)
 	HandleStatus(ctx context.Context) string
+	HandleSetBirthday(ctx context.Context, userID int64, dateStr string) (string, error)
+	HandleRemoveBirthday(ctx context.Context, userID int64) (string, error)
+	HandleGetBirthdaysOfMonth(ctx context.Context) (string, error)
+	HandleTodayBirthdays(ctx context.Context) (string, error)
 }
 
 // ModerationRepository handles persistence of moderation records.

--- a/internal/core/services/bot_service.go
+++ b/internal/core/services/bot_service.go
@@ -5,7 +5,11 @@ package services
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
+	"sort"
+	"strconv"
+	"strings"
 	"time"
 
 	"github.com/Golang-Venezuela/adan-bot/internal/core/domain"
@@ -29,7 +33,7 @@ func NewBotService(repo ports.UserRepository) ports.BotService {
 // HandleStartHelp provides the standard response string for the /start and /help bot commands.
 func (s *botService) HandleStartHelp(ctx context.Context) string {
 	slog.Debug("Handling StartHelp context globally")
-	return "/hola and /status."
+	return "/hola, /status, /micumple DD/MM, /borrarcumple and /cumples_mes."
 }
 
 // HandleHola processes the /hola command.
@@ -56,7 +60,7 @@ func (s *botService) HandleHola(ctx context.Context, userID int64, username, fir
 	msg := "Hola mi nombre es Adan el Bot 🤖 de la comunidad de Golang"
 	msg += " Venezuela. Y como la cancion: <<naci en esta ribera del "
 	msg += "arauca vibrador, soy hermano de la espuma de las garzas de "
-	msg += "las rosas y del sol.>> "
+	msg += "las rosas and del sol.>> "
 	return msg, nil
 }
 
@@ -65,4 +69,158 @@ func (s *botService) HandleStatus(ctx context.Context) string {
 	slog.Debug("Handling Status context globally")
 	//nolint:misspell
 	return "De momento todo esta bien"
+}
+
+// HandleSetBirthday parses, validates, and registers a user's birthday date.
+func (s *botService) HandleSetBirthday(ctx context.Context, userID int64, dateStr string) (string, error) {
+	day, month, err := parseBirthday(dateStr)
+	if err != nil {
+		slog.Warn("Invalid birthday format", slog.String("input", dateStr), slog.Any("error", err))
+		return fmt.Sprintf("❌ Error: %s. Por favor usa el formato DD/MM (ejemplo: /micumple 15/10)", err.Error()), nil
+	}
+
+	err = s.userRepo.SetBirthday(ctx, userID, day, month)
+	if err != nil {
+		return "❌ Tuve un problema interno al guardar tu cumpleaños.", err
+	}
+
+	return fmt.Sprintf("🎉 ¡Guardado! Tu cumpleaños ha sido registrado para el %02d/%02d.", day, month), nil
+}
+
+// HandleRemoveBirthday deletes a user's birthday registration from persistence.
+func (s *botService) HandleRemoveBirthday(ctx context.Context, userID int64) (string, error) {
+	err := s.userRepo.RemoveBirthday(ctx, userID)
+	if err != nil {
+		return "❌ Tuve un problema interno al eliminar tu cumpleaños.", err
+	}
+	return "🗑️ Tu fecha de cumpleaños ha sido eliminada.", nil
+}
+
+// HandleGetBirthdaysOfMonth retrieves and formats the list of birthdays for the current month.
+func (s *botService) HandleGetBirthdaysOfMonth(ctx context.Context) (string, error) {
+	loc, err := time.LoadLocation("America/Caracas")
+	if err != nil {
+		loc = time.UTC
+	}
+	now := time.Now().In(loc)
+	month := int(now.Month())
+
+	users, err := s.userRepo.GetBirthdaysByMonth(ctx, month)
+	if err != nil {
+		return "❌ Tuve un problema interno al buscar los cumpleaños.", err
+	}
+
+	if len(users) == 0 {
+		return fmt.Sprintf("📅 No hay cumpleaños registrados para el mes de %s.", translateMonth(month)), nil
+	}
+
+	// Sort users chronologically by birthday_day
+	sort.Slice(users, func(i, j int) bool {
+		di := 0
+		dj := 0
+		if users[i].BirthdayDay != nil {
+			di = *users[i].BirthdayDay
+		}
+		if users[j].BirthdayDay != nil {
+			dj = *users[j].BirthdayDay
+		}
+		return di < dj
+	})
+
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("📅 <b>Cumpleaños de %s:</b>\n\n", translateMonth(month)))
+	for _, u := range users {
+		dayVal := 0
+		if u.BirthdayDay != nil {
+			dayVal = *u.BirthdayDay
+		}
+
+		var name string
+		if u.Username != "" {
+			name = "@" + u.Username
+		} else {
+			name = fmt.Sprintf("<a href=\"tg://user?id=%d\">%s</a>", u.ID, u.FirstName)
+		}
+		sb.WriteString(fmt.Sprintf("🎂 Día %02d: %s\n", dayVal, name))
+	}
+
+	return sb.String(), nil
+}
+
+// HandleTodayBirthdays checks for birthdays today and builds a celebration message if any.
+func (s *botService) HandleTodayBirthdays(ctx context.Context) (string, error) {
+	loc, err := time.LoadLocation("America/Caracas")
+	if err != nil {
+		loc = time.UTC
+	}
+	now := time.Now().In(loc)
+	day := now.Day()
+	month := int(now.Month())
+
+	users, err := s.userRepo.GetBirthdaysByDayAndMonth(ctx, day, month)
+	if err != nil {
+		return "", err
+	}
+
+	if len(users) == 0 {
+		return "", nil // No birthdays today
+	}
+
+	var mentions []string
+	for _, u := range users {
+		if u.Username != "" {
+			mentions = append(mentions, "@"+u.Username)
+		} else {
+			mentions = append(mentions, fmt.Sprintf("<a href=\"tg://user?id=%d\">%s</a>", u.ID, u.FirstName))
+		}
+	}
+
+	var msg string
+	if len(users) == 1 {
+		msg = fmt.Sprintf("🎂 ¡Hoy es un día especial en Golang Venezuela! Queremos desearle un muy feliz cumpleaños a %s. ¡Que tengas un excelente día programando y celebrando! 🥳🎉", mentions[0])
+	} else {
+		listStr := strings.Join(mentions[:len(mentions)-1], ", ") + " y " + mentions[len(mentions)-1]
+		msg = fmt.Sprintf("🎂 ¡Hoy es un día especial en Golang Venezuela! Queremos desearle un muy feliz cumpleaños a %s. ¡Que tengan un excelente día programando y celebrando! 🥳🎉", listStr)
+	}
+
+	return msg, nil
+}
+
+// parseBirthday validates and extracts day and month from a "DD/MM" formatted string.
+func parseBirthday(dateStr string) (int, int, error) {
+	dateStr = strings.TrimSpace(dateStr)
+	parts := strings.Split(dateStr, "/")
+	if len(parts) != 2 {
+		return 0, 0, fmt.Errorf("formato incorrecto")
+	}
+
+	day, err := strconv.Atoi(parts[0])
+	if err != nil {
+		return 0, 0, fmt.Errorf("día inválido")
+	}
+
+	month, err := strconv.Atoi(parts[1])
+	if err != nil {
+		return 0, 0, fmt.Errorf("mes inválido")
+	}
+
+	if month < 1 || month > 12 {
+		return 0, 0, fmt.Errorf("el mes debe estar entre 1 y 12")
+	}
+
+	daysInMonth := []int{0, 31, 29, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31}
+	if day < 1 || day > daysInMonth[month] {
+		return 0, 0, fmt.Errorf("el día %d no es válido para el mes %d", day, month)
+	}
+
+	return day, month, nil
+}
+
+// translateMonth converts a month number into its Spanish name.
+func translateMonth(month int) string {
+	months := []string{"", "Enero", "Febrero", "Marzo", "Abril", "Mayo", "Junio", "Julio", "Agosto", "Septiembre", "Octubre", "Noviembre", "Diciembre"}
+	if month < 1 || month > 12 {
+		return ""
+	}
+	return months[month]
 }

--- a/internal/core/services/bot_service_test.go
+++ b/internal/core/services/bot_service_test.go
@@ -1,0 +1,274 @@
+package services
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Golang-Venezuela/adan-bot/internal/core/domain"
+)
+
+type mockUserRepo struct {
+	users map[int64]domain.User
+}
+
+func newMockUserRepo() *mockUserRepo {
+	return &mockUserRepo{
+		users: make(map[int64]domain.User),
+	}
+}
+
+func (m *mockUserRepo) SaveUser(ctx context.Context, u domain.User) error {
+	m.users[u.ID] = u
+	return nil
+}
+
+func (m *mockUserRepo) GetUserByID(ctx context.Context, id int64) (*domain.User, error) {
+	u, ok := m.users[id]
+	if !ok {
+		return nil, nil
+	}
+	return &u, nil
+}
+
+func (m *mockUserRepo) SetBirthday(ctx context.Context, userID int64, day, month int) error {
+	u, ok := m.users[userID]
+	if !ok {
+		u = domain.User{ID: userID}
+	}
+	u.BirthdayDay = &day
+	u.BirthdayMonth = &month
+	m.users[userID] = u
+	return nil
+}
+
+func (m *mockUserRepo) RemoveBirthday(ctx context.Context, userID int64) error {
+	u, ok := m.users[userID]
+	if !ok {
+		return nil
+	}
+	u.BirthdayDay = nil
+	u.BirthdayMonth = nil
+	m.users[userID] = u
+	return nil
+}
+
+func (m *mockUserRepo) GetBirthdaysByDayAndMonth(ctx context.Context, day, month int) ([]domain.User, error) {
+	var result []domain.User
+	for _, u := range m.users {
+		if u.BirthdayDay != nil && *u.BirthdayDay == day && u.BirthdayMonth != nil && *u.BirthdayMonth == month {
+			result = append(result, u)
+		}
+	}
+	return result, nil
+}
+
+func (m *mockUserRepo) GetBirthdaysByMonth(ctx context.Context, month int) ([]domain.User, error) {
+	var result []domain.User
+	for _, u := range m.users {
+		if u.BirthdayMonth != nil && *u.BirthdayMonth == month {
+			result = append(result, u)
+		}
+	}
+	return result, nil
+}
+
+func TestBotService_HandleSetBirthday(t *testing.T) {
+	repo := newMockUserRepo()
+	svc := NewBotService(repo)
+	ctx := context.Background()
+	userID := int64(12345)
+
+	tests := []struct {
+		name     string
+		input    string
+		wantOk   bool
+		contains string
+	}{
+		{
+			name:     "Valid birthday Oct 15",
+			input:    "15/10",
+			wantOk:   true,
+			contains: "¡Guardado!",
+		},
+		{
+			name:     "Valid birthday leap day Feb 29",
+			input:    "29/02",
+			wantOk:   true,
+			contains: "¡Guardado!",
+		},
+		{
+			name:     "Invalid day 32",
+			input:    "32/01",
+			wantOk:   false,
+			contains: "Error",
+		},
+		{
+			name:     "Invalid month 13",
+			input:    "15/13",
+			wantOk:   false,
+			contains: "Error",
+		},
+		{
+			name:     "Invalid separator",
+			input:    "15-10",
+			wantOk:   false,
+			contains: "Error",
+		},
+		{
+			name:     "Empty input",
+			input:    "",
+			wantOk:   false,
+			contains: "Error",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			msg, err := svc.HandleSetBirthday(ctx, userID, tt.input)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if !strings.Contains(msg, tt.contains) {
+				t.Errorf("expected message to contain %q, but got %q", tt.contains, msg)
+			}
+
+			if tt.wantOk {
+				user, err := repo.GetUserByID(ctx, userID)
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				if user.BirthdayDay == nil || user.BirthdayMonth == nil {
+					t.Errorf("expected birthday to be saved in repository")
+				}
+			}
+		})
+	}
+}
+
+func TestBotService_HandleRemoveBirthday(t *testing.T) {
+	repo := newMockUserRepo()
+	svc := NewBotService(repo)
+	ctx := context.Background()
+	userID := int64(12345)
+
+	// Set initial birthday
+	_ = repo.SetBirthday(ctx, userID, 15, 10)
+
+	msg, err := svc.HandleRemoveBirthday(ctx, userID)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !strings.Contains(msg, "eliminada") {
+		t.Errorf("expected confirmation message, got %q", msg)
+	}
+
+	user, _ := repo.GetUserByID(ctx, userID)
+	if user.BirthdayDay != nil || user.BirthdayMonth != nil {
+		t.Errorf("expected birthday to be nil after deletion")
+	}
+}
+
+func TestBotService_HandleGetBirthdaysOfMonth(t *testing.T) {
+	repo := newMockUserRepo()
+	svc := NewBotService(repo)
+	ctx := context.Background()
+
+	loc, err := time.LoadLocation("America/Caracas")
+	if err != nil {
+		loc = time.UTC
+	}
+	now := time.Now().In(loc)
+	currentMonth := int(now.Month())
+
+	// Add users
+	user1 := domain.User{ID: 1, Username: "user_one", FirstName: "One"}
+	user2 := domain.User{ID: 2, FirstName: "Two"} // No username
+
+	_ = repo.SaveUser(ctx, user1)
+	_ = repo.SaveUser(ctx, user2)
+
+	// Set birthdays
+	_ = repo.SetBirthday(ctx, 1, 20, currentMonth) // user1
+	_ = repo.SetBirthday(ctx, 2, 5, currentMonth)  // user2
+
+	msg, err := svc.HandleGetBirthdaysOfMonth(ctx)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Verify header contains current month name (translated)
+	monthName := translateMonth(currentMonth)
+	if !strings.Contains(msg, monthName) {
+		t.Errorf("expected message to contain %q, but got %q", monthName, msg)
+	}
+
+	// Verify user1 is mentioned using @username
+	if !strings.Contains(msg, "@user_one") {
+		t.Errorf("expected message to contain username @user_one, got %q", msg)
+	}
+
+	// Verify user2 (no username) is mentioned using FirstName html link
+	if !strings.Contains(msg, "Two") || !strings.Contains(msg, "tg://user?id=2") {
+		t.Errorf("expected message to contain FirstName link for user 2, got %q", msg)
+	}
+
+	// Verify chronological sorting (Day 05 should appear before Day 20)
+	idx5 := strings.Index(msg, "Día 05")
+	idx2 := strings.Index(msg, "Día 20")
+	if idx5 == -1 || idx2 == -1 || idx5 > idx2 {
+		t.Errorf("expected Day 05 to be listed before Day 20, got indexing: 05=%d, 20=%d", idx5, idx2)
+	}
+}
+
+func TestBotService_HandleTodayBirthdays(t *testing.T) {
+	repo := newMockUserRepo()
+	svc := NewBotService(repo)
+	ctx := context.Background()
+
+	loc, err := time.LoadLocation("America/Caracas")
+	if err != nil {
+		loc = time.UTC
+	}
+	now := time.Now().In(loc)
+	day := now.Day()
+	month := int(now.Month())
+
+	// No birthdays today
+	msg, err := svc.HandleTodayBirthdays(ctx)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if msg != "" {
+		t.Errorf("expected empty message when there are no birthdays today, got %q", msg)
+	}
+
+	// Add single birthday today
+	u1 := domain.User{ID: 10, Username: "celebrant1", FirstName: "C1"}
+	_ = repo.SaveUser(ctx, u1)
+	_ = repo.SetBirthday(ctx, 10, day, month)
+
+	msg, err = svc.HandleTodayBirthdays(ctx)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(msg, "@celebrant1") || !strings.Contains(msg, "cumpleaños") {
+		t.Errorf("expected birthday greeting for @celebrant1, got %q", msg)
+	}
+
+	// Add second birthday today
+	u2 := domain.User{ID: 11, FirstName: "C2"} // No username
+	_ = repo.SaveUser(ctx, u2)
+	_ = repo.SetBirthday(ctx, 11, day, month)
+
+	msg, err = svc.HandleTodayBirthdays(ctx)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(msg, "@celebrant1") || !strings.Contains(msg, "C2") || !strings.Contains(msg, "y") {
+		t.Errorf("expected joint birthday greeting for both users, got %q", msg)
+	}
+}


### PR DESCRIPTION
## Description

This change implements the Community Birthday System for `adan-bot` using `sqlx` to map SQLite rows to domain entities. It introduces user commands to manage birthdays, view upcoming celebrants, and automatically triggers daily greetings for active members.

Summary of changes:
- **Domain & Ports**: Added `BirthdayDay` and `BirthdayMonth` to `domain.User` and updated the corresponding port interfaces.
- **Repository (SQLite)**: Refactored `user_repo.go` to use `sqlx.DB` and implemented programmatic auto-migrations to add birthday columns.
- **Core Service**: Added business logic validation for dates (`DD/MM` format), birthday deletion, monthly lists, and today's greetings compilation.
- **Delivery (Telegram)**: Registered `/micumple`, `/borrarcumple`, and `/cumples_mes` commands.
- **Schedulers**: Added a daily 8:00 AM VET background scheduler for VM/standalone deploys and a serverless HTTP trigger path (`/tasks/check-birthdays`) for AWS Lambda deploys.
- **Makefile**: Fixed automated test coverage reports folder creation dynamically.

Fixes: #35

## Testing

### 1. Automated Unit and Integration Tests
Run the Go test suite locally:
```bash
make test
